### PR TITLE
Added iOS v16 dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "SecretsManager",
-    platforms: [.macOS(.v13)],
+    platforms: [.iOS(.v16),.macOS(.v13)],
     products: [
         .executable(name: "SecretsManager", targets: ["SecretsManager"]),
         .plugin(name: "SecretsManagerPlugin", targets: ["SecretsManagerPlugin"]),


### PR DESCRIPTION
Added .iOS(.v16) platform dependency to match the main.swift dependency.  This will resolve a compiler error when other packages have a earlier dependency.